### PR TITLE
feat: add CI/CD workflow for CLI with path-based triggers

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -1,0 +1,111 @@
+name: CLI Lint & Test
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'cli/**'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'cli/**'
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v5
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Cache pip dependencies
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('cli/requirements*.txt', 'requirements/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        # Install from requirements.txt if it exists in cli/ or requirements/
+        if [ -f cli/requirements.txt ]; then
+          pip install -r cli/requirements.txt
+        elif [ -f requirements/requirements.txt ]; then
+          pip install -r requirements/requirements.txt
+        fi
+        # Install linting and testing tools
+        pip install flake8 black isort mypy pytest pytest-cov
+
+    - name: Run Black (Code Formatter Check)
+      run: |
+        black --check --diff cli/
+
+    - name: Run isort (Import Sorting Check)
+      run: |
+        isort --check-only --diff cli/
+
+    - name: Run Flake8 (Linting)
+      run: |
+        flake8 cli/ --count --select=E9,F63,F7,F82 --show-source --statistics
+        flake8 cli/ --count --exit-zero --max-complexity=10 --max-line-length=88 --statistics
+
+    - name: Run MyPy (Type Checking)
+      run: |
+        mypy cli/ --ignore-missing-imports || true
+
+    - name: Test CLI Installation
+      run: |
+        cd cli
+        python -m pip install -e .
+        # Test CLI commands work
+        python cli.py --help
+        python cli.py hello greet --help
+
+  test:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v5
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        if [ -f cli/requirements.txt ]; then
+          pip install -r cli/requirements.txt
+        elif [ -f requirements/requirements.txt ]; then
+          pip install -r requirements/requirements.txt
+        fi
+        pip install pytest pytest-cov
+
+    - name: Install CLI package
+      run: |
+        cd cli
+        pip install -e .
+
+    - name: Run Tests
+      run: |
+        cd cli
+        # Run tests if they exist
+        if [ -f test_*.py ] || [ -f *_test.py ] || [ -d tests ]; then
+          pytest --cov=. --cov-report=term-missing
+        else
+          echo "No tests found, running basic smoke test"
+          python cli.py --help
+        fi


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for the CLI component, ensuring automated linting, type checking, and testing on every push and pull request affecting the `cli/` directory. The workflow is designed to enforce code quality and reliability for CLI development.

**New CI workflow for CLI:**

* Added a `.github/workflows/cli.yml` workflow that runs on pushes and pull requests to `main` affecting the `cli/` directory. It includes jobs for linting (using Black, isort, Flake8, and MyPy) and testing (using pytest and pytest-cov), as well as installation checks for the CLI.