### PR TITLE
Add ignore paths in ibis gha

### DIFF
--- a/.github/workflows/ibis.yml
+++ b/.github/workflows/ibis.yml
@@ -4,9 +4,15 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'cli/**'
+      - '.github/workflows/cli.yml'
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - 'cli/**'
+      - '.github/workflows/cli.yml'
 
 permissions:
   contents: write


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to prevent unnecessary runs when changes are made only to CLI-related files or workflows. Specifically, it ensures that the `ibis.yml` workflow is not triggered by changes to the CLI directory or its workflow file.

Workflow trigger improvements:

* Updated `.github/workflows/ibis.yml` to ignore changes in the `cli/**` directory and the `.github/workflows/cli.yml` file for both `push` and `pull_request` events, reducing redundant workflow runs.