### PR TITLE
feature : adds global version

### DIFF
--- a/cli/__version__.py
+++ b/cli/__version__.py
@@ -24,10 +24,10 @@ def _discover_package_version() -> str:
         try:
             with open(setup_path, "r", encoding="utf-8") as f:
                 content = f.read()
-            match = re.search(r"version=\"([^\"]+)\"", content)
+            match = re.search(r"version\s*=\s*[\"'](.*?)[\"']", content)
             if match:
                 return match.group(1)
-        except Exception:
+        except (OSError, IOError, UnicodeDecodeError):
             pass
 
     return "0.0.0"

--- a/cli/__version__.py
+++ b/cli/__version__.py
@@ -1,0 +1,41 @@
+import os
+import re
+from importlib.metadata import PackageNotFoundError, version as pkg_version
+
+
+APP_NAME = "101-linux"
+
+
+def _discover_package_version() -> str:
+    """Discover version from installed package or local setup.py when running from source.
+
+    - Prefer the installed distribution version (if available)
+    - Fallback to parsing version from cli/setup.py (source checkout)
+    - Lastly, fallback to "0.0.0" if nothing else is found
+    """
+    try:
+        return pkg_version("linux-commands-cli")
+    except PackageNotFoundError:
+        pass
+
+    setup_path = os.path.join(os.path.dirname(__file__), "setup.py")
+    if os.path.exists(setup_path):
+        try:
+            with open(setup_path, "r", encoding="utf-8") as f:
+                content = f.read()
+            match = re.search(r"version=\"([^\"]+)\"", content)
+            if match:
+                return match.group(1)
+        except Exception:
+            pass
+
+    return "0.0.0"
+
+
+__version__ = _discover_package_version()
+
+
+def get_version_string() -> str:
+    return f"{APP_NAME} v{__version__}"
+
+

--- a/cli/__version__.py
+++ b/cli/__version__.py
@@ -4,6 +4,7 @@ from importlib.metadata import PackageNotFoundError, version as pkg_version
 
 
 APP_NAME = "101-linux"
+PACKAGE_NAME = "linux-commands-cli"
 
 
 def _discover_package_version() -> str:
@@ -14,11 +15,11 @@ def _discover_package_version() -> str:
     - Lastly, fallback to "0.0.0" if nothing else is found
     """
     try:
-        return pkg_version("linux-commands-cli")
+        return pkg_version(PACKAGE_NAME)
     except PackageNotFoundError:
         pass
 
-    setup_path = os.path.join(os.path.dirname(__file__), "setup.py")
+    setup_path = os.path.join(os.path.dirname(__file__), "..", "setup.py")
     if os.path.exists(setup_path):
         try:
             with open(setup_path, "r", encoding="utf-8") as f:

--- a/cli/cli.py
+++ b/cli/cli.py
@@ -5,8 +5,31 @@ CLI entry point for the 101 Linux Commands application.
 import typer
 
 from commands import hello
+from __version__ import get_version_string
 
 app = typer.Typer(help="101 Linux Commands CLI 🚀")
+
+
+def _version_callback(value: bool):
+    if value:
+        typer.echo(get_version_string())
+        raise typer.Exit()
+
+
+@app.callback()
+def main(
+    version: bool = typer.Option(
+        False,
+        "--version",
+        help="Show the application version and exit.",
+        is_eager=True,
+        callback=_version_callback,
+    )
+):
+    """Main entrypoint for global options."""
+    return
+
+# Register subcommands
 app.add_typer(hello.app, name="hello")
 
 

--- a/cli/test_cli.py
+++ b/cli/test_cli.py
@@ -5,6 +5,9 @@ import os
 import subprocess
 import sys
 
+sys.path.insert(0, os.path.dirname(__file__))
+from __version__ import get_version_string
+
 
 def test_cli_help():
     """Test that the CLI shows help."""
@@ -56,6 +59,19 @@ def test_hello_help():
     )
     assert result.returncode == 0
     assert "Hello command group" in result.stdout
+
+
+def test_global_version_flag():
+    """Test the global --version flag prints version and exits."""
+    result = subprocess.run(
+        [sys.executable, "cli.py", "--version"],
+        capture_output=True,
+        text=True,
+        cwd=os.path.dirname(__file__),
+    )
+    assert result.returncode == 0
+    expected = get_version_string()
+    assert result.stdout.strip() == expected
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
What type of PR is this? (check all applicable)
[ ] ♻️ Refactor
[ ] ✨ New Chapter
[ ] 🐛 Bug Fix/Typo
[ ] 👷 Optimization
[ ] 📝 Documentation Update

[x] 🚩 Other
Description
Add a global --version flag to the CLI so users can run python cli.py --version without a subcommand.
Introduce cli/__version__.py with get_version_string() to centralize version information.
Implement dynamic version discovery:
Prefer the installed package version (linux-commands-cli) via importlib.metadata.
Fallback to parsing cli/setup.py when running from source.
Fallback to 0.0.0 if no version is found.
Add tests for the global --version flag and update tests to assert against get_version_string() instead of a hardcoded string.
Related Tickets & Documents
N/A
Added to documentation?
[ ] 📜 readme
[x] 🙅 no documentation needed
[optional] What gif best describes this PR or how it makes you feel?
N/A
If you prefer a different type classification, we could also tag this as “👷 Optimization” since it improves UX and testability without changing chapters.

<img width="1470" height="956" alt="Version global and testcase" src="https://github.com/user-attachments/assets/11225048-c440-45c8-b8e5-ff8abeb6a40d" />

