### PR TITLE
docs: Correct and enhance 'free' command documentation

### DIFF
--- a/ebook/en/content/018-the-free-command.md
+++ b/ebook/en/content/018-the-free-command.md
@@ -10,7 +10,7 @@ The `free` command in Linux/Unix is used to show memory (RAM/SWAP) information.
 --- Output the memory usage - available and used, as well as swap
 
 **Details:**
---- Outputted values are not human-readable (are in bytes)
+--- The values are shown in kibibytes by default.
 
 **Command:**
 ```
@@ -28,4 +28,16 @@ free
 **Command:**
 ```
 free -h
+```
+## Show memory usage with a total line
+
+**Action:**
+--- Output the memory usage and also add a summary line with the total.
+
+**Details:**
+--- The `-t` flag is useful for seeing the combined total of memory and swap.
+
+**Command:**
+```
+free -t
 ```


### PR DESCRIPTION
Hello! This PR fixes a small error and adds a new example for the `free` command, as requested in Issue #190.

- Corrected the default unit from bytes to kibibytes.
- Added an example for the `-t` flag.

Thanks for the opportunity to contribute!