### PR TITLE
docs: Enhance and clarify 'help' command documentation

### DIFF
--- a/ebook/en/content/011-the-help-command.md
+++ b/ebook/en/content/011-the-help-command.md
@@ -4,6 +4,8 @@ Display information about builtin commands.
 
 If a `PATTERN` is specified, this command gives detailed help on all commands matching the `PATTERN`, otherwise the list of available help topics is printed.
 
+> **Quick Tip:** The `help` command only works for commands that are "built-in" to the Bash shell itself (like `cd`, `pwd`, `echo`, `read`). It will not work for standalone programs like `ls`, `grep`, or `find`. To get help for those, you should use the `man` command (e.g., `man ls`).
+
 ## Syntax
 ```bash
 $ help [-dms] [PATTERN ...]
@@ -20,12 +22,22 @@ $ help [-dms] [PATTERN ...]
 1. We get the complete information about the `cd` command
 ```bash
 $ help cd
+cd: cd [-L|[-P [-e]] [-@]] [dir]
+    Change the shell working directory.
+
+    Change the current directory to DIR.  The default DIR is the value of the
+    HOME shell variable.
+...
+(additional details about options and exit status follow)
 ```
 2. We get a short description about the `pwd` command
 ```bash 	
 $ help -d pwd
+pwd: pwd [-LP]
+    Print the name of the current working directory.
 ```
 3. We get the syntax of the `cd` command
 ```bash
 $ help -s cd
+cd [-L|[-P [-e]] [-@]] [dir]
 ```

--- a/ebook/en/content/018-the-free-command.md
+++ b/ebook/en/content/018-the-free-command.md
@@ -10,7 +10,7 @@ The `free` command in Linux/Unix is used to show memory (RAM/SWAP) information.
 --- Output the memory usage - available and used, as well as swap
 
 **Details:**
---- Outputted values are not human-readable (are in bytes)
+--- The values are shown in kibibytes by default.
 
 **Command:**
 ```
@@ -28,4 +28,16 @@ free
 **Command:**
 ```
 free -h
+```
+## Show memory usage with a total line
+
+**Action:**
+--- Output the memory usage and also add a summary line with the total.
+
+**Details:**
+--- The `-t` flag is useful for seeing the combined total of memory and swap.
+
+**Command:**
+```
+free -t
 ```


### PR DESCRIPTION
Addresses #190.

This PR improves the chapter on the `help` command by:
- Adding a "Quick Tip" to explain what "builtin" commands are and how they differ from other programs.
- Including the output for all examples to make them clearer.

Thanks!