### PR TITLE
fix(html): fix ordered-list numbering

### DIFF
--- a/ebook/en/export/101-linux-commands.html
+++ b/ebook/en/export/101-linux-commands.html
@@ -385,16 +385,12 @@
             font-size: 0.7rem;
         }
 
-        .content-wrapper ol {
-            counter-reset: list-counter;
-        }
-
-        .content-wrapper ol li {
-            counter-increment: list-counter;
-        }
 
         .content-wrapper ol li::before {
-            content: counter(list-counter);
+            display: none;
+        }
+
+        .content-wrapper .list-badge {
             position: absolute;
             left: 0;
             background: var(--accent-color);
@@ -10964,6 +10960,7 @@ b=`expr substr $a <span class="hljs-number">6</span> <span class="hljs-number">1
             loadPreferences();
             setupEventListeners();
             updateActiveNavigation();
+            injectOrderedListBadges();
             
             if (window.innerWidth > 1024) {
                 toggleSidebar();
@@ -11224,6 +11221,36 @@ b=`expr substr $a <span class="hljs-number">6</span> <span class="hljs-number">1
                 }
             }
         });
+
+        // Add numeric badges for ordered lists
+        function injectOrderedListBadges() {
+            try {
+                const content = document.querySelector('.content-wrapper');
+                if (!content) return;
+
+                content.querySelectorAll('ol').forEach(function(ol){
+                    let start = parseInt(ol.getAttribute('start') || '1', 10);
+                    if (Number.isNaN(start)) start = 1;
+
+                    Array.from(ol.children).forEach(function(li, idx){
+                        if (li.querySelector('.list-badge')) return;
+
+                        const badge = document.createElement('span');
+                        badge.className = 'list-badge';
+                        badge.textContent = String(start + idx);
+
+                        if (getComputedStyle(li).position === 'static') {
+                            li.style.position = 'relative';
+                        }
+
+                        li.insertBefore(badge, li.firstChild);
+                        li.style.paddingLeft = '2.2rem';
+                    });
+                });
+            } catch (err) {
+                console.error('Failed to inject list badges', err);
+            }
+        }
     </script>
 </body>
 </html>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] ♻️ Refactor
- [ ] ✨ New Chapter
- [x] 🐛 Bug Fix/Typo
- [ ] 👷 Optimization
- [ ] 📝 Documentation Update
- [ ] 🚩 Other

## Description

Fixes a rendering bug where CSS list markers reset when lists are split by code blocks by hiding pseudo markers and injecting numeric badges via a small JS helper.

## Related Tickets & Documents

__**ref: #378**__

## Added to documentation?

- [ ] 📜 readme
- [x] 🙅 no documentation needed

<img width="458" height="498" alt="image" src="https://github.com/user-attachments/assets/a6fe1429-757f-4f8f-b724-3a6ad6d4f978" />
