### PR TITLE
Document the sync command with usage examples  - hacktoberfest

### DIFF
--- a/ebook/en/content/138-the-syc-command.md
+++ b/ebook/en/content/138-the-syc-command.md
@@ -1,0 +1,23 @@
+# The `sync` command
+
+The sync command flushes file system buffers, ensuring that data in memory is written to disk. It’s often used before shutdowns or unmounting disks.
+
+Syntax:
+sync [OPTIONS] [FILE]
+
+Examples:
+
+To flush all filesystem buffers:
+```
+sync
+```
+
+To flush a specific file to disk:
+```
+sync myfile.txt
+```
+### Additional Flags and their Functionalities:
+|**Short Flag**   |**Long Flag**   |**Description**   |
+|:---|:---|:---|
+|`<center>-</center>`|`	--data`|	Flush only data, not metadata.|
+|`<center>-</center>`|`	--file-system`|	Sync the entire file system containing FILE.|


### PR DESCRIPTION
This pull request adds documentation for the `sync` command to the ebook, providing an overview of its usage, syntax, examples, and available flags.

New documentation:

* Added a new section describing the purpose and usage of the `sync` command, including syntax and practical examples (`ebook/en/content/138-the-syc-command.md`).
* Included a table outlining additional flags for the `sync` command, detailing their functionalities (`ebook/en/content/138-the-syc-command.md`).