### PR TITLE
Fix typo: 'though' to 'through' in scp command

### DIFF
--- a/ebook/en/content/076-the-scp-command.md
+++ b/ebook/en/content/076-the-scp-command.md
@@ -27,7 +27,7 @@ scp root@{remote-ip-address}:/home/remote-file /home/documents/
 ```
 scp root@{remote1-ip-address}:/home/remote-file root@{remote2-ip-address}/home/
 ```
-4. To copy file though a jump host server. 
+4. To copy file through a jump host server. 
 ```
 scp /home/documents/local-file -oProxyJump=<jump-host-ip> root@{remote-ip-address}/home/
 ```


### PR DESCRIPTION
## Description

Corrected a spelling error in line 30 of `076-the-scp-command.md` where 'though' was used instead of 'through' in the context of copying files through a jump host server.

## Changes Made

- Fixed typo: "To copy file though a jump host server" → "To copy file through a jump host server"
- File: `ebook/en/content/076-the-scp-command.md`
- Line: 30

## Type of Change

- [x] Bug fix (typo correction)
- [ ] New feature
- [ ] Documentation update

## Checklist

- [x] I have read the Contributing Guide
- [x] My commit message is descriptive
- [x] I have made only one small, focused change