### PR TITLE
Fix typos and improve clarity in command documentation

### DIFF
--- a/ebook/en/content/001-the-ls-command.md
+++ b/ebook/en/content/001-the-ls-command.md
@@ -75,7 +75,7 @@ In this interactive tutorial, you will learn the different ways to use the `ls` 
 |`-r`|`--reverse`|Show files and directories in reverse order *(descending alphabetical order)*|
 |`-a`|`--all`|Show all files, including hidden files *(file names which begin with a period `.`)*|
 |`-la`|<center>-</center>|Show long format files and directories including hidden files|
-|`-lh`|<center>-</center>|list long format files and directories with readable size|
+|`-lh`|<center>-</center>|List long format files and directories with readable size|
 |`-A`|`--almost-all`|Shows all like `-a` but without showing `.`(current working directory) and `..` (parent directory)|
 |`-d`|`--directory`|Instead of listing the files and directories inside the directory, it shows any information about the directory itself, it can be used with `-l` to show long formatted information|
 |`-F`|`--classify`|Appends an indicator character to the end of each listed name, as an example: `/` character is appended after each directory name listed|

--- a/ebook/en/content/003-the-cat-tac-command.md
+++ b/ebook/en/content/003-the-cat-tac-command.md
@@ -85,7 +85,6 @@ cat [OPTION] [FILE]...
 |`-e`|<center>-</center>| equivalent to -vE|
 |`-T`|<center>-</center>|Display tab separated lines in file opened with ```cat``` command.|
 |`-E`|<center>-</center>|To show $ at the end of each file.|
-|`-E`|<center>-</center>|Display file with line numbers.|
 |`-n`| `--number`|number all output lines|
 |`-s`| `--squeeze-blank`|suppress repeated empty output lines|
 |`-u`|<center>-</center>|(ignored)|

--- a/ebook/en/content/007-the-touch-command.md
+++ b/ebook/en/content/007-the-touch-command.md
@@ -18,10 +18,7 @@ touch [OPTION]... FILE...
 |`-m`|<center>-</center>|Change only the modification time.|
 |`-r=FILE`|`--reference=FILE`|Use this file's times instead of the current time.|
 |`-t STAMP`|<center>-</center>|Use the numeric time  *STAMP*  instead of the current time. The format of *STAMP*  is [[**CC**]**YY**]**MMDDhhmm**[**.ss**].|
-|<center>-</center>|`--time=WORD`|An alternate way to specify which type of time is set (e.g. *access*, *modification*, or *change*). This is equivalent to specifying `-a` or `-m`.
-
-- WORD is `access`, `atime`, or `use`: equivalent to `-a`.
-- WORD is `modify` or `mtime`: equivalent to `-m`.
+|<center>-</center>|`--time=WORD`|An alternate way to specify which type of time is set (e.g. *access*, *modification*, or *change*). This is equivalent to specifying `-a` or `-m`- WORD is `access`, `atime` : equivalent to `-a` or WORD is `modify` or `mtime` : equivalent to `-m`.
 
 An alternate way to specify what type of time to set (as with  **-a**  and  **-m**).|
 |<center>-</center>|`--help`|Display a help message, and exit.|

--- a/ebook/en/content/009-the-bc-command.md
+++ b/ebook/en/content/009-the-bc-command.md
@@ -11,16 +11,16 @@ Input : $ echo "11+5" | bc
 Output : 16
 ```
 2 . Increment:
-- var –++ : Post increment operator, the result of the variable is used first and then the variable is incremented.
-- – ++var : Pre increment operator, the variable is increased first and then the result of the variable is stored.
+- var++ : Post increment operator, the result of the variable is used first and then the variable is incremented.
+- ++var : Pre increment operator, the variable is increased first and then the result of the variable is stored.
 
 ```
 Input: $ echo "var=3;++var" | bc
 Output: 4
 ```
 3 . Decrement:
-- var – – : Post decrement operator, the result of the variable is used first and then the variable is decremented.
-- – – var : Pre decrement operator, the variable is decreased first and then the result of the variable is stored.
+- var–– : Post decrement operator, the result of the variable is used first and then the variable is decremented.
+- ––var : Pre decrement operator, the variable is decreased first and then the result of the variable is stored.
 
 ```
 Input: $ echo "var=3;--var" | bc

--- a/ebook/en/content/041-the-ifconfig-command.md
+++ b/ebook/en/content/041-the-ifconfig-command.md
@@ -93,7 +93,7 @@ Please note that the alias network address is in the same subnet mask of the net
 ```
 ifconfig eth0:0 down
 ```
-Remember that for every scope  (i.e.  same  net  with  address/netmask  combination)  all aiases are deleted, if you delete the first alias.
+Remember that for every scope  (i.e.  same  net  with  address/netmask  combination)  all aliases are deleted, if you delete the first alias.
 ### Help Command
 Run below command to view the complete guide to `ifconfig` command.
 ```


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Contributing Guide: https://github.com/bobbyiliev/101-linux-commands/blob/HEAD/CONTRIBUTING.md#creating-a-pull-request.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] ♻️ Refactor
- [ ] ✨ New Chapter
- [x ] 🐛 Bug Fix/Typo
- [ ] 👷 Optimization
- [ ] 📝 Documentation Update
- [ ] 🚩 Other

## Description

# Document Review: 101 Linux Commands

The following table outlines the corrections required for the "101 Linux Commands" eBook.

| # | Command / Section | Issue | Original Text | Correction |
| :--- | :--- | :--- | :--- | :--- |
| 1 | `ls` (Additional Flags) | **Spelling/Consistency:** Lowercase start in description. | "...list long format files..." | Capitalize to "**List**" for consistency with other entries. |
| 2 | `cat` (Additional Flags) | **Duplicate/Logic Error:** Duplicate entry for flag `-E`. | Two rows for `-E`. Second row says "Display file with line numbers". | Remove the second `-E` row. The correct flag for line numbers is `-n`. |
| 3 | `touch` (Options) | **Formatting:** Table row for `--time=WORD` is broken/spilled. | "An alternate way to specify what type of time to set..." is in a new unformatted row. | Merge the spilled text back into the description cell for `--time=WORD`. |
| 4 | `ifconfig` (Example 11 & 12) | **Spelling:** Typo in "promiscuous". | "To enable **promiscous** mode..." | Change to "**promiscuous**". |
| 5 | `ifconfig` (Example 14) | **Spelling:** Typo in "aliases". | "...all **aiases** are deleted..." | Change to "**aliases**". |
| 6 | `bc` (Example 2 & 3) | **Formatting:** Non-standard characters (en-dashes) used for code. | Uses "–++" and "– –" (long dashes). | Replace with standard ASCII characters: `++var` and `--var` for copy-paste compatibility. |

## Detailed Notes

### Command Syntax Fixes
For the `bc` command, ensure the operators use standard terminal-friendly characters:
* **Increment:** `++var` or `var++`
* **Decrement:** `--var` or `var--`

### General Consistency
Ensure all descriptions in the "Additional Flags" and "Options" tables begin with a capital letter to match the style found in the `ls` and `man` page standards.


## Related Tickets & Documents



## Added to documentation?

- [ ] 📜 readme
- [x ] 🙅 no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?
👍 